### PR TITLE
Split getJSONAssignment into getJSONStringAssignment and getParsedJSONAssignment by bumping common library version [FF-966]

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "1.4.1",
+    "@eppo/js-client-sdk-common": "1.5.0",
     "@react-native-async-storage/async-storage": "^1.18.0",
     "axios": "^0.27.2",
     "md5": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "1.5.0",
+    "@eppo/js-client-sdk-common": "1.5.1",
     "@react-native-async-storage/async-storage": "^1.18.0",
     "axios": "^0.27.2",
     "md5": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -98,6 +98,9 @@
       "<rootDir>/example/node_modules",
       "<rootDir>/lib/"
     ],
+    "moduleNameMapper": {
+      "@eppo(.*)": "<rootDir>/node_modules/@eppo/$1"
+    },
     "setupFiles": ["./jestSetup.js"],
     "testEnvironment": "node"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/react-native-sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "test",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -229,13 +229,13 @@ describe('EppoReactNativeClient E2E test', () => {
         expectedAssignments,
       }: IAssignmentTestCase) => {
         console.log(`---- Test Case for ${experiment} Experiment ----`);
-        const assignments = subjectsWithAttributes
-          ? getAssignmentsWithSubjectAttributes(
-              subjectsWithAttributes,
-              experiment,
-              valueType
-            )
-          : getAssignments(subjects, experiment, valueType);
+        const assignments = getAssignmentsWithSubjectAttributes(
+          subjectsWithAttributes
+            ? subjectsWithAttributes
+            : subjects.map((subject) => ({ subjectKey: subject })),
+          experiment,
+          valueType
+        );
 
         switch (valueType) {
           case ValueTestType.BoolType: {
@@ -275,43 +275,10 @@ describe('EppoReactNativeClient E2E test', () => {
     });
   });
 
-  function getAssignments(
-    subjects: string[],
-    experiment: string,
-    valueTestType: ValueTestType = ValueTestType.StringType
-  ): (EppoValue | null)[] {
-    return subjects.map((subjectKey) => {
-      switch (valueTestType) {
-        case ValueTestType.BoolType: {
-          const ba = client.getBoolAssignment(subjectKey, experiment);
-          if (ba === null) return null;
-          return EppoValue.Bool(ba);
-        }
-        case ValueTestType.NumericType: {
-          const na = client.getNumericAssignment(subjectKey, experiment);
-          if (na === null) return null;
-          return EppoValue.Numeric(na);
-        }
-        case ValueTestType.StringType: {
-          const sa = client.getStringAssignment(subjectKey, experiment);
-          if (sa === null) return null;
-          return EppoValue.String(sa);
-        }
-        case ValueTestType.JSONType: {
-          const sa = client.getJSONStringAssignment(subjectKey, experiment);
-          const oa = client.getParsedJSONAssignment(subjectKey, experiment);
-          if (oa == null || sa === null) return null;
-          return EppoValue.JSON(sa, oa);
-        }
-      }
-    });
-  }
-
   function getAssignmentsWithSubjectAttributes(
     subjectsWithAttributes: {
       subjectKey: string;
-
-      subjectAttributes: Record<string, any>;
+      subjectAttributes?: Record<string, any>;
     }[],
     experiment: string,
     valueTestType: ValueTestType = ValueTestType.StringType

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -7,9 +7,16 @@ export const TEST_DATA_DIR = './test/data/';
 export const ASSIGNMENT_TEST_DATA_DIR = TEST_DATA_DIR + 'assignment-v2/';
 export const MOCK_RAC_RESPONSE_FILE = 'rac-experiments-v3.json';
 
+export enum ValueTestType {
+  BoolType = 'boolean',
+  NumericType = 'numeric',
+  StringType = 'string',
+  JSONType = 'json',
+}
+
 export interface IAssignmentTestCase {
   experiment: string;
-  valueType: string;
+  valueType: ValueTestType;
   percentExposure: number;
   variations: IVariation[];
   subjects: string[];

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -20,7 +20,6 @@ export interface IAssignmentTestCase {
   percentExposure: number;
   variations: IVariation[];
   subjects: string[];
-
   subjectsWithAttributes: {
     subjectKey: string;
     subjectAttributes: Record<string, any>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1260,10 +1260,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@eppo/js-client-sdk-common@1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-1.4.1.tgz#b75bb34c9004ea34070be38250532e04d2683e83"
-  integrity sha512-1dPursZSgtJb7ufLbePI1qIryydFTP6Y+EJYiV+I1njhBEdIUjc/E1+Qe3kBDSXoyowrk8VjUZGV4RD4YnPhcA==
+"@eppo/js-client-sdk-common@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-1.5.0.tgz#b18ee3f4506605813865b251411d1ee02a6e4825"
+  integrity sha512-mxM9tJInCUWMkS3hjlMil2pPMYMrryaaM+zw7Uxatq/ILKYD64RqyFa/6iO3L9M0tv6Tcl3weWvQKE5Nurj0YA==
   dependencies:
     axios "^0.27.2"
     md5 "^2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1260,10 +1260,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@eppo/js-client-sdk-common@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-1.5.0.tgz#b18ee3f4506605813865b251411d1ee02a6e4825"
-  integrity sha512-mxM9tJInCUWMkS3hjlMil2pPMYMrryaaM+zw7Uxatq/ILKYD64RqyFa/6iO3L9M0tv6Tcl3weWvQKE5Nurj0YA==
+"@eppo/js-client-sdk-common@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-1.5.1.tgz#f4f86c17aaf8da565613a85ffc6b5f133a382a6a"
+  integrity sha512-cO7lkqO1I0d3aOu43+jeiUTNFn4Rkrg95Fc6ADhLFwYjV3b0hI7KRUPE66YadjgP3Db3J2XgBWtQps2XFbfe5Q==
   dependencies:
     axios "^0.27.2"
     md5 "^2.3.0"


### PR DESCRIPTION
Fixes: [FF-966](https://linear.app/eppo/issue/FF-966/react-native)

## Description

* Bumps common library version to [v1.5.1](https://github.com/Eppo-exp/js-client-sdk-common/releases/tag/v1.5.1)
  * [v1.5.0](https://github.com/Eppo-exp/js-client-sdk-common/releases/tag/v1.5.0) splits `getJSONAssignment` into `getJSONStringAssignment` and `getParsedJSONAssignment`
  * [v1.5.1](https://github.com/Eppo-exp/js-client-sdk-common/releases/tag/v1.5.1) has a bug fix that includes `getParsedJSONAssignment` as a property in `IEppoClient`
* Adds tests to support each of the typed assignment methods

## How has this been tested?

Running `yarn test`