### PR TITLE
Use yarn instead of npm in github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Download test data
-        run: make test-data
-
       - name: Run unit tests
         run: yarn test --maxWorkers=2 --coverage
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      - name: Install dependencies
+        run: yarn install
+
       - name: Run unit tests
         run: yarn test --maxWorkers=2 --coverage
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,8 +11,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - run: npm install
-      - run: npm test
+      - run: yarn install
+      - run: yarn test
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "!**/.*"
   ],
   "scripts": {
+    "prepare": "make test-data",
     "test": "jest",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Publishing package to npm failed/times out due to not finding the test data

https://github.com/Eppo-exp/react-native-sdk/actions/runs/6276868579/job/17047456930

```
FAIL src/__tests__/index.test.tsx
  ● Test suite failed to run

    ENOENT: no such file or directory, scandir './test/data/assignment-v2/'

      33 | export function readAssignmentTestData(): IAssignmentTestCase[] {
      34 |   const testCaseData: IAssignmentTestCase[] = [];
    > 35 |   const testCaseFiles = fs.readdirSync(ASSIGNMENT_TEST_DATA_DIR);
         |                            ^
      36 |   testCaseFiles.forEach((file) => {
      37 |     const testCase = JSON.parse(
      38 |       fs.readFileSync(ASSIGNMENT_TEST_DATA_DIR + file, 'utf8')

      at readdirSync (test/testHelpers.ts:35:28)
      at src/__tests__/index.test.tsx:21[9](https://github.com/Eppo-exp/react-native-sdk/actions/runs/6276868579/job/17047456930#step:5:10):44
      at describe (src/__tests__/index.test.tsx:218:3)
      at Object.describe (src/__tests__/index.test.tsx:[17](https://github.com/Eppo-exp/react-native-sdk/actions/runs/6276868579/job/17047456930#step:5:18):1)
```

Also, we made a change in the js client SDK to use yarn: https://github.com/Eppo-exp/js-client-sdk/pull/25 where we were also having a `Test suite failed to run` error, though due to a different reason, but you can see that `yarn test` runs without issue in CI https://github.com/Eppo-exp/react-native-sdk/actions/runs/6330383728/job/17192663552 so it seems safer to be consistent about using yarn to publish as well.

## Description
[//]: # (Describe your changes in detail)

Similar changes were also made in the common library: https://github.com/Eppo-exp/js-client-sdk-common/pull/7

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

Tested that `yarn install` and `yarn test` works in CI https://github.com/Eppo-exp/react-native-sdk/actions/runs/6330793713/job/17193995109?pr=12

It remains to be seen if this fixes the publish workflow

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
