### PR TITLE
FF-1110 fix ts resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "test",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
-  "types": "lib/typescript/index.d.ts",
+  "types": "lib/typescript/src/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",
   "files": [


### PR DESCRIPTION
@leoromanovsky when I was ready to give up, i found one tiny little difference between 0.3.0 and 0.3.2 versions.

In 0.3.0 we have:

<img width="1261" alt="0 3 0" src="https://github.com/Eppo-exp/react-native-sdk/assets/83206611/264c2812-e198-40d4-8ed6-9309e596ace7">

While folder structure changes in 0.3.2:

<img width="1173" alt="0 3 2" src="https://github.com/Eppo-exp/react-native-sdk/assets/83206611/4e833c79-d342-4459-bd39-5826c0920dc3">


I checked in my test app by adjusting node_modules/@eppo/react-native-sdk/package.json

setting `"types": "lib/typescript/src/index.d.ts",` and it seems to be working