### PR TITLE
Fix setup in actions: remove packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
   "engines": {
     "node": ">= 16.0.0"
   },
-  "packageManager": "^yarn@1.22.15",
   "jest": {
     "preset": "react-native",
     "modulePathIgnorePatterns": [


### PR DESCRIPTION
Error when setting up the test:

![Screenshot 2023-11-20 at 9 41 19 AM](https://github.com/Eppo-exp/react-native-sdk/assets/2822951/f82438f7-b50c-4728-9249-bf4be10c0964)

Corepack isn't being used in this project and it's unclear why `packageManager` is in `package.json`. And removing it seems to fix the issue, so seems to be okay to just do this to fix actions.
