### PR TITLE
fix: include package.json on lib folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "jest",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
-    "prepack": "bob build",
+    "prepack": "bob build && cp -r package.json lib",
     "example": "yarn --cwd example",
     "bootstrap": "yarn example && yarn install"
   },


### PR DESCRIPTION
Using the Eppo `react-native-sdk`, we faced into this error running `react-native bundle` command:

```
$ react-native bundle --entry-file index.js --dev false --bundle-output bundle.min.js
[DETOX *.e2e.ts|tsx mocking]: OFF
                    Welcome to Metro!
              Fast - Scalable - Integrated
error Unable to resolve module ../package.json from /my_project/node_modules/@eppo/react-native-sdk/lib/commonjs/sdk-data.js: 
None of these files exist:
  * package.json
  * node_modules/@eppo/react-native-sdk/lib/package.json/index(.native|.ios.js|.native.js|.js|.ios.json|.native.json|.json|.ios.ts|.native.ts|.ts|.ios.tsx|.native.tsx|.tsx|.ios.svg|.native.svg|.svg|.ios.cjs|.native.cjs|.cjs)
   5 | });
   6 | exports.sdkVersion = exports.sdkName = void 0;
>  7 | const packageJson = require('../package.json');
     |                              ^
   8 | const sdkVersion = exports.sdkVersion = packageJson.version;
   9 | const sdkName = exports.sdkName = 'react-native-sdk';
```

The reason is because `sdk-data.ts` file is requiring the `package.json` file [here](https://github.com/Eppo-exp/react-native-sdk/blob/0cbf9d2540dc1b628666bcc8139380cf2ed1a0f4/src/sdk-data.ts#L1), but when the package is transpiled and published, the directories structure is different than the source code, having a nested `lib` folder.

This PR fixes the issue including the `package.json` in the correct path after building.