### PR TITLE
Pavel/add check types on prepack

### DIFF
--- a/check-types.js
+++ b/check-types.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+
+// Load package.json
+const packageJsonPath = path.join(__dirname, 'package.json');
+const packageJson = require(packageJsonPath);
+
+// Get the "types" field from package.json
+const typesFilePath = packageJson.types;
+
+if (!typesFilePath) {
+  console.error('The "types" field is not defined in package.json.');
+  process.exit(1);
+}
+
+// Resolve the full path to the types file
+const typesFileFullPath = path.resolve(__dirname, typesFilePath);
+
+// Check if the file exists
+fs.access(typesFileFullPath, fs.constants.F_OK, (err) => {
+  if (err) {
+    console.error(`The types file '${typesFileFullPath}' does not exist.`);
+    process.exit(1);
+  } else {
+    console.log(`The types file '${typesFileFullPath}' exists.`);
+  }
+});

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,5 +7,5 @@ pre-commit:
       run: npx eslint {files}
     types:
       files: git diff --name-only @{push}
-      glob: "*.{js,ts, jsx, tsx}"
+      glob: "*.{ts, tsx}"
       run: npx tsc --noEmit

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,10 +2,10 @@ pre-commit:
   parallel: true
   commands:
     lint:
-      files: git diff --name-only @{push}
+      files: git diff --cached --name-only
       glob: "*.{js,ts,jsx,tsx}"
       run: npx eslint {files}
     types:
-      files: git diff --name-only @{push}
-      glob: "*.{ts, tsx}"
+      files: git diff --cached --name-only
+      glob: "*.{ts,tsx}"
       run: npx tsc --noEmit

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@eppo/react-native-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Eppo React Native SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
-  "types": "lib/typescript/src/index.d.ts",
+  "types": "lib/typescript/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",
   "files": [
@@ -31,9 +31,10 @@
     "test": "jest",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
-    "prepack": "bob build && cp -r package.json lib",
+    "prepack": "bob build && cp -r package.json lib && yarn check-types",
     "example": "yarn --cwd example",
-    "bootstrap": "yarn example && yarn install"
+    "bootstrap": "yarn example && yarn install",
+    "check-types": "node ./check-types.js"
   },
   "keywords": [
     "react-native",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -79,6 +79,8 @@ export class EppoReactNativeClient extends EppoClient {
 export async function init(config: IClientConfig): Promise<IEppoClient> {
   validation.validateNotBlank(config.apiKey, 'API key required');
 
+  console.log('opana');
+
   try {
     // If any existing instances; ensure they are not polling
     if (EppoReactNativeClient.instance) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -79,8 +79,6 @@ export class EppoReactNativeClient extends EppoClient {
 export async function init(config: IClientConfig): Promise<IEppoClient> {
   validation.validateNotBlank(config.apiKey, 'API key required');
 
-  console.log('opana');
-
   try {
     // If any existing instances; ensure they are not polling
     if (EppoReactNativeClient.instance) {


### PR DESCRIPTION
Fixes: FF-2138

There is an error with typescript types resolution, when using this SDK.

When users try to import sdk, they get an error:

<img width="427" alt="1" src="https://github.com/Eppo-exp/react-native-sdk/assets/83206611/b4af9746-b1e3-4fb4-b75c-b7846582571c">

We already fixed this once, in another pr. In it, we had to change types directive from 

`"types": "lib/typescript/index.d.ts",` to `"types": "lib/typescript/src/index.d.ts",`

It looks like we need to revert this change, but it is not clear, why it happens.

I started to investigate, and found why:

This issue with lib/typescript/src  is definitely caused by adding removing files to `/test` folder.
If it contains ts tests files - we have `lib/typescript/src`
If there are not ts tests files in `/test` folder - we have simple `lib/typescript/`

I tested this on v3.0.0 by :

first just ran yarn prepack, it resulted in `lib/typescript/index.d.ts`
Than removed lib, and created a simple test file in `/test` folder, like:

```
import express from 'express';

const api = express();

api.get('/randomized_assignment/v3/config', (_req, res) => {
  const mockRacResponse = JSON.stringify({ some: 'object' });
  res.json(mockRacResponse);
});

const server = api.listen(4000, () => {
  const address = server.address();
  console.log(`Running API server on '${JSON.stringify(address)}'...`);
});

export default server;
```

ran `yarn prepack` and have the folder structure with `lib/typescript/src` folder


To avoid having this error in future, I added another check to prepack command, which after lib generation, will check if types directive in package.json is defined correctly