### PR TITLE
FF-3014 fix: "throwOnFailedInitialization" option should throw init errors

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -110,6 +110,7 @@ export async function init(config: IClientConfig): Promise<EppoClient> {
 
     await EppoReactNativeClient.instance.fetchFlagConfigurations();
 
+    EppoReactNativeClient.initialized = true;
     return EppoReactNativeClient.instance;
   } catch (error) {
     console.warn(
@@ -118,8 +119,6 @@ export async function init(config: IClientConfig): Promise<EppoClient> {
     if (config.throwOnFailedInitialization ?? true) {
       throw error;
     }
-  } finally {
-    EppoReactNativeClient.initialized = true;
     return EppoReactNativeClient.instance;
   }
 }


### PR DESCRIPTION
Update SDK so that `throwOnFailedInitialization` throws specific errors. Before it wasn't doing this.

### Local testing

<img width="415" alt="Screenshot 2024-08-12 at 8 30 50 AM" src="https://github.com/user-attachments/assets/b67414fa-4eb9-4db1-8db0-aa14fe42bf3e">

<img width="730" alt="Screenshot 2024-08-12 at 8 31 22 AM" src="https://github.com/user-attachments/assets/cdca5d28-09fe-47db-a2d1-2cf8ad765d56">

Before this change, this log message wouldn't show up because the `catch` wouldn't be triggered in the init call. Now it does.