### PR TITLE
quality: parameterize sdk and test data branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,9 @@
 name: CI
+
+env:
+  SDK_BRANCH_NAME: ${{ inputs.sdk_branch  || github.head_ref || github.ref_name || 'main' }}
+  TEST_DATA_BRANCH_NAME: ${{ inputs.test_data_branch || 'main' }}
+
 on:
   push:
     branches:
@@ -6,13 +11,29 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
+  workflow_call:
+    inputs:
+      test_data_branch:
+        type: string
+        description: The branch in sdk-test-data to target for testcase files
+        required: false
+        default: main
+      sdk_branch:
+        type: string
+        description: The branch of the SDK to test
+        required: false
+      
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          repository: Eppo-exp/react-native-sdk
+          ref: ${{ env.SDK_BRANCH_NAME}}
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -33,6 +54,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          repository: Eppo-exp/react-native-sdk
+          ref: ${{ env.SDK_BRANCH_NAME}}
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -46,13 +70,16 @@ jobs:
         run: yarn install
 
       - name: Run unit tests
-        run: yarn test --maxWorkers=2 --coverage
+        run: make test branchName=${{env.TEST_DATA_BRANCH_NAME}}
 
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          repository: Eppo-exp/react-native-sdk
+          ref: ${{ env.SDK_BRANCH_NAME}}
 
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,14 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+
     steps:
+      - name: Display Testing Details
+        run: |
+          echo "Running SDK Test using"
+          echo "Test Data: sdk-test-data@${TEST_DATA_BRANCH_NAME}"
+          echo "SDK Branch: php-sdk@${SDK_BRANCH_NAME}"
+
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,7 @@ test-data:
 	cp ${gitDataDir}rac-experiments-v3.json ${testDataDir}
 	cp -r ${gitDataDir}assignment-v2 ${testDataDir}
 	rm -rf ${tempDir}
+
+.PHONY: test
+test: test-data
+	yarn test --maxWorkers=2 --coverage


### PR DESCRIPTION
🎟️ Fixes FF-3093 towards FF-3085

👯‍♂️ **Related PRs**
- [sdk-test-data](https://github.com/Eppo-exp/sdk-test-data/pull/59)
- [golang-sdk](https://github.com/Eppo-exp/golang-sdk/pull/66)
- [ios-sdk](https://github.com/Eppo-exp/eppo-ios-sdk/pull/40)
- [android-sdk](https://github.com/Eppo-exp/android-sdk/pull/93)

### Motivation
Changes are often made to the [sdk-test-data](https://github.com/Eppo-exp/sdk-test-data) repository to capture new behaviours, bugs and edge cases. When these changes are pushed to `main`, the SDKs are cloned locally (locally to the github action running) and their respective tests are run. These tests are set up and run by copies of the SDK test workflows - see [sdk-test-data workflow](https://github.com/Eppo-exp/sdk-test-data/blob/main/.github/workflows/test-sdks.yml). There are a number of limitations to this setup:

- Test steps are copied from the SDK’s respective workflows; changes to the SDK test workflows need to be replicated in sdk-test-data and this is not obvious to devs
- The SDK tests are not able to run against in-flight changes to `sdk-test-data`
- When new test-data is committed that breaks an SDK, that breakage is not surfaced in the SDK’s repository until some action triggers its testing workflow (on demand, on pull-request, etc.).

### Description of Changes
_This change_
🚀 - Each SDK's testing workflow is enhanced into a [reusable workflow](https://docs.github.com/en/actions/sharing-automations/reusing-workflows), exposing parameters for SDK branch and the sdk-test-data branch to use in testing.
- The test workflow runs using the main branch of sdk-test-data on all main pushes and Pull Requests using the PR's branch

_External to this Change_
[sdk-test-data](https://github.com/Eppo-exp/sdk-test-data/blob/main/.github/workflows) get two testing workflows.
1. ♻️  "Local Testing"- For all pull request changes, the "Local Testing" workflow calls the reusable SDK workflows, test results are recorded only in the sdk-test-data action. This is run using the main SDK branch and the "current" branch of workflow, i.e. the pull request branch. (SDK repo does not see/is not notified of test failures during PR lifecycle, only on push to main)
2. ♻️ 🧑‍💻 "Remote Testing" - On all pushes to the main branch of sdk-test-data, the SDK testing workflows are triggered to run within their respective repositories, alerting all subscribers of failed runs (repo is red/green).