### PR TITLE
Support non-ascii characters by upgrading common JS core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,4 @@ lib/
 .node-version
 .python-version
 
-test/data
+src/__tests__/data

--- a/Makefile
+++ b/Makefile
@@ -24,18 +24,17 @@ help: Makefile
 	@sed -n 's/^##//p' $<
 
 ## test-data
-testDataDir := test/data/
+testDataDir := src/__tests__/data/
 tempDir := ${testDataDir}temp/
 gitDataDir := ${tempDir}sdk-test-data/
 branchName := main
 githubRepoLink := https://github.com/Eppo-exp/sdk-test-data.git
 .PHONY: test-data
-test-data: 
+test-data:
 	rm -rf $(testDataDir)
 	mkdir -p $(tempDir)
 	git clone -b ${branchName} --depth 1 --single-branch ${githubRepoLink} ${gitDataDir}
-	cp ${gitDataDir}rac-experiments-v3.json ${testDataDir}
-	cp -r ${gitDataDir}assignment-v2 ${testDataDir}
+	cp -r ${gitDataDir}ufc ${testDataDir}
 	rm -rf ${tempDir}
 
 .PHONY: test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/react-native-sdk",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Eppo React Native SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -51,7 +51,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "4.3.0",
+    "@eppo/js-client-sdk-common": "^4.7.1",
     "@react-native-async-storage/async-storage": "^1.18.0",
     "md5": "^2.3.0"
   },

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -105,7 +105,9 @@ describe('EppoReactNativeClient integration test', () => {
     const mockConfigStore = td.object<EppoAsyncStorage>();
     const mockLogger = td.object<IAssignmentLogger>();
     td.when(mockConfigStore.get(flagKey)).thenReturn(null);
-    const client_instance = new EppoReactNativeClient(mockConfigStore);
+    const client_instance = new EppoReactNativeClient({
+      flagConfigurationStore: mockConfigStore,
+    });
     client_instance.setLogger(mockLogger);
     const assignment = client_instance.getStringAssignment(
       flagKey,
@@ -120,7 +122,9 @@ describe('EppoReactNativeClient integration test', () => {
     const mockConfigStore = td.object<EppoAsyncStorage>();
     const mockLogger = td.object<IAssignmentLogger>();
     td.when(mockConfigStore.get(flagKey)).thenReturn(mockExperimentConfig);
-    const client_instance = new EppoReactNativeClient(mockConfigStore);
+    const client_instance = new EppoReactNativeClient({
+      flagConfigurationStore: mockConfigStore,
+    });
     client_instance.setLogger(mockLogger);
     const assignment = client_instance.getStringAssignment(
       flagKey,
@@ -151,7 +155,9 @@ describe('EppoReactNativeClient integration test', () => {
       new Error('logging error')
     );
     td.when(mockConfigStore.get(flagKey)).thenReturn(mockExperimentConfig);
-    const client_instance = new EppoReactNativeClient(mockConfigStore);
+    const client_instance = new EppoReactNativeClient({
+      flagConfigurationStore: mockConfigStore,
+    });
     client_instance.setLogger(mockLogger);
     const assignment = client_instance.getStringAssignment(
       flagKey,

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -10,10 +10,9 @@ import {
 import { EppoReactNativeClient, getInstance, init } from '..';
 import {
   getTestAssignments,
-  type IAssignmentTestCase,
   OBFUSCATED_MOCK_UFC_RESPONSE_FILE,
-  readAssignmentTestData,
   readMockUfcResponse,
+  testCasesByFileName,
   validateTestAssignments,
 } from './testHelpers';
 
@@ -266,18 +265,21 @@ describe('UFC Obfuscated Test Cases', () => {
     jest.restoreAllMocks();
   });
 
-  it.each(readAssignmentTestData())(
-    'test variation assignment splits',
-    async ({
-      flag,
-      variationType,
-      defaultValue,
-      subjects,
-    }: IAssignmentTestCase) => {
+  const testCases = testCasesByFileName();
+
+  it.each(Object.keys(testCases))(
+    'Shared obfuscated test case - %s',
+    async (fileName: string) => {
+      const testCase = testCases[fileName];
+      if (!testCase) {
+        throw new Error('Test case failed to load from ' + fileName);
+      }
+      const { flag, defaultValue, subjects, variationType } = testCase;
+
       const client = getInstance();
 
       const typeAssignmentFunctions = {
-        [VariationType.BOOLEAN]: client.getBoolAssignment.bind(client),
+        [VariationType.BOOLEAN]: client.getBooleanAssignment.bind(client),
         [VariationType.NUMERIC]: client.getNumericAssignment.bind(client),
         [VariationType.INTEGER]: client.getIntegerAssignment.bind(client),
         [VariationType.STRING]: client.getStringAssignment.bind(client),

--- a/src/__tests__/testHelpers.ts
+++ b/src/__tests__/testHelpers.ts
@@ -1,0 +1,91 @@
+import * as fs from 'fs';
+import * as path from 'node:path';
+
+import type {
+  Flag,
+  VariationType,
+  AttributeType,
+} from '@eppo/js-client-sdk-common';
+
+export const TEST_DATA_DIR = path.resolve(__dirname, 'data', 'ufc');
+export const ASSIGNMENT_TEST_DATA_DIR = path.join(TEST_DATA_DIR, 'tests');
+export const OBFUSCATED_MOCK_UFC_RESPONSE_FILE = `flags-v1-obfuscated.json`;
+
+export interface SubjectTestCase {
+  subjectKey: string;
+  subjectAttributes: Record<string, AttributeType>;
+  assignment: string | number | boolean | object;
+}
+
+export interface IAssignmentTestCase {
+  flag: string;
+  variationType: VariationType;
+  defaultValue: string | number | boolean | object;
+  subjects: SubjectTestCase[];
+}
+
+export function readMockUfcResponse(filename: string): {
+  flags: Record<string, Flag>;
+} {
+  return JSON.parse(fs.readFileSync(TEST_DATA_DIR + filename, 'utf-8'));
+}
+
+export function readAssignmentTestData(): IAssignmentTestCase[] {
+  const testCaseData: IAssignmentTestCase[] = [];
+  const testCaseFiles = fs.readdirSync(ASSIGNMENT_TEST_DATA_DIR);
+  testCaseFiles.forEach((file) => {
+    const testCase = JSON.parse(
+      fs.readFileSync(path.join(ASSIGNMENT_TEST_DATA_DIR, file), 'utf8')
+    );
+    testCaseData.push(testCase);
+  });
+  return testCaseData;
+}
+
+export function getTestAssignments(
+  testCase: IAssignmentTestCase,
+  assignmentFn: any,
+  obfuscated = false
+): {
+  subject: SubjectTestCase;
+  assignment: string | boolean | number | object;
+}[] {
+  const assignments: {
+    subject: SubjectTestCase;
+    assignment: string | boolean | number | object;
+  }[] = [];
+  for (const subject of testCase.subjects) {
+    const assignment =
+      assignmentFn(
+        testCase.flag,
+        subject.subjectKey,
+        subject.subjectAttributes,
+        testCase.defaultValue,
+        obfuscated
+      ) || testCase.defaultValue; // Fallback to defaultValue if null
+    assignments.push({ subject: subject, assignment: assignment });
+  }
+  return assignments;
+}
+
+export function validateTestAssignments(
+  assignments: {
+    subject: SubjectTestCase;
+    assignment: string | boolean | number | object;
+  }[],
+  flag: string
+) {
+  for (const { subject, assignment } of assignments) {
+    if (typeof assignment !== 'object') {
+      // the expect works well for objects, but this comparison does not
+      if (assignment !== subject.assignment) {
+        throw new Error(
+          `subject ${
+            subject.subjectKey
+          } was assigned ${assignment?.toString()} when expected ${subject.assignment?.toString()} for flag ${flag}`
+        );
+      }
+    }
+    expect(subject.assignment).toEqual(assignment);
+  }
+}

--- a/src/__tests__/testHelpers.ts
+++ b/src/__tests__/testHelpers.ts
@@ -27,19 +27,28 @@ export interface IAssignmentTestCase {
 export function readMockUfcResponse(filename: string): {
   flags: Record<string, Flag>;
 } {
-  return JSON.parse(fs.readFileSync(TEST_DATA_DIR + filename, 'utf-8'));
+  return JSON.parse(
+    fs.readFileSync(path.join(TEST_DATA_DIR, filename), 'utf-8')
+  );
 }
 
-export function readAssignmentTestData(): IAssignmentTestCase[] {
-  const testCaseData: IAssignmentTestCase[] = [];
-  const testCaseFiles = fs.readdirSync(ASSIGNMENT_TEST_DATA_DIR);
-  testCaseFiles.forEach((file) => {
-    const testCase = JSON.parse(
-      fs.readFileSync(path.join(ASSIGNMENT_TEST_DATA_DIR, file), 'utf8')
-    );
-    testCaseData.push(testCase);
+export function testCasesByFileName(): Record<string, IAssignmentTestCase> {
+  const testDirectory = ASSIGNMENT_TEST_DATA_DIR;
+  const testCasesWithFileName: Array<
+    IAssignmentTestCase & { fileName: string }
+  > = fs.readdirSync(testDirectory).map((fileName) => ({
+    ...JSON.parse(fs.readFileSync(path.join(testDirectory, fileName), 'utf8')),
+    fileName,
+  }));
+  if (!testCasesWithFileName.length) {
+    throw new Error('No test cases at ' + testDirectory);
+  }
+  const mappedTestCase: Record<string, IAssignmentTestCase> = {};
+  testCasesWithFileName.forEach((testCaseWithFileName) => {
+    mappedTestCase[testCaseWithFileName.fileName] = testCaseWithFileName;
   });
-  return testCaseData;
+
+  return mappedTestCase;
 }
 
 export function getTestAssignments(
@@ -75,6 +84,7 @@ export function validateTestAssignments(
   }[],
   flag: string
 ) {
+  expect(assignments.length).toBeGreaterThan(0);
   for (const { subject, assignment } of assignments) {
     if (typeof assignment !== 'object') {
       // the expect works well for objects, but this comparison does not

--- a/src/async-storage.ts
+++ b/src/async-storage.ts
@@ -3,10 +3,11 @@ import type {
   IConfigurationStore,
   ISyncStore,
 } from '@eppo/js-client-sdk-common';
-import type {
-  Environment,
-  Flag,
-  ObfuscatedFlag,
+import {
+  type Environment,
+  type Flag,
+  FormatEnum,
+  type ObfuscatedFlag,
 } from '@eppo/js-client-sdk-common/dist/interfaces';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
@@ -59,6 +60,7 @@ export class EppoAsyncStorage
   private environment: Environment | null = null;
   private configFetchedAt: string | null = null;
   private configPublishedAt: string | null = null;
+  private format: FormatEnum | null = null;
 
   constructor() {
     this.servingStore = new AsyncStorageStore<Flag | ObfuscatedFlag>();
@@ -66,6 +68,7 @@ export class EppoAsyncStorage
     this.initialized = false;
     this.configFetchedAt = '';
     this.configPublishedAt = '';
+    this.format = FormatEnum.CLIENT;
   }
 
   init(): Promise<void> {
@@ -123,5 +126,13 @@ export class EppoAsyncStorage
 
   public setConfigPublishedAt(configPublishedAt: string): void {
     this.configPublishedAt = configPublishedAt;
+  }
+
+  getFormat(): FormatEnum | null {
+    return this.format;
+  }
+
+  setFormat(format: FormatEnum): void {
+    this.format = format;
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -78,13 +78,10 @@ const asyncStorage = new EppoAsyncStorage();
 export class EppoReactNativeClient extends EppoClient {
   public static initialized = false;
 
-  public static instance: EppoReactNativeClient = new EppoReactNativeClient(
-    asyncStorage,
-    undefined,
-    undefined,
-    undefined,
-    true
-  );
+  public static instance: EppoReactNativeClient = new EppoReactNativeClient({
+    flagConfigurationStore: asyncStorage,
+    isObfuscated: true,
+  });
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1213,15 +1213,17 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@eppo/js-client-sdk-common@4.3.0":
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.3.0.tgz#66c0e5904091ac1a9c2bc3bf4017637b13404ce8"
-  integrity sha512-ur270vCZjUuKuEohF1vH7yh1MBxtDbVcduCJzJmJ6m7kjoyvqNPzG/+lYPEol6Bpr9wV42ciIB+A1cYeNZ7gSA==
+"@eppo/js-client-sdk-common@^4.7.1":
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.7.1.tgz#8a0776055604af65d0e0f8410d4756aa3117992f"
+  integrity sha512-8+5WbFN1EvsS5Ba/qakjDGEhp9loTxSvVHeWaQXKKLXxV+5AhFNOl+d8jSwOkLnP+Qr5D9w1eO7lfzuNDkUcWw==
   dependencies:
+    buffer "npm:@eppo/buffer@6.2.0"
     js-base64 "^3.7.7"
-    md5 "^2.3.0"
-    pino "^8.19.0"
+    pino "^9.5.0"
     semver "^7.5.4"
+    spark-md5 "^3.0.2"
+    uuid "^8.3.2"
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
@@ -2736,10 +2738,10 @@ buffer@^5.5.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
-buffer@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
-  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+"buffer@npm:@eppo/buffer@6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@eppo/buffer/-/buffer-6.2.0.tgz#c073617a106ec710e83835edd593ab55ad2b25a1"
+  integrity sha512-3SP9je+cXr2tHRCwG38P862MjjNALoM4/FGR5ciqjTb6xpJpJxHI1mg0ORwn0Shu8Prn6mUpqqzyAxCvszb8uw==
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
@@ -3701,11 +3703,6 @@ event-target-shim@^5.0.0, event-target-shim@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
-
-events@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
-  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
 execa@^1.0.0:
   version "1.0.0"
@@ -6472,35 +6469,34 @@ pify@^4.0.1:
   resolved "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
-pino-abstract-transport@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz#97f9f2631931e242da531b5c66d3079c12c9d1b5"
-  integrity sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==
+pino-abstract-transport@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz#de241578406ac7b8a33ce0d77ae6e8a0b3b68a60"
+  integrity sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==
   dependencies:
-    readable-stream "^4.0.0"
     split2 "^4.0.0"
 
-pino-std-serializers@^6.0.0:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz#d9a9b5f2b9a402486a5fc4db0a737570a860aab3"
-  integrity sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==
+pino-std-serializers@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz#7c625038b13718dbbd84ab446bd673dc52259e3b"
+  integrity sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==
 
-pino@^8.19.0:
-  version "8.21.0"
-  resolved "https://registry.yarnpkg.com/pino/-/pino-8.21.0.tgz#e1207f3675a2722940d62da79a7a55a98409f00d"
-  integrity sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==
+pino@^9.5.0:
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-9.6.0.tgz#6bc628159ba0cc81806d286718903b7fc6b13169"
+  integrity sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg==
   dependencies:
     atomic-sleep "^1.0.0"
     fast-redact "^3.1.1"
     on-exit-leak-free "^2.1.0"
-    pino-abstract-transport "^1.2.0"
-    pino-std-serializers "^6.0.0"
-    process-warning "^3.0.0"
+    pino-abstract-transport "^2.0.0"
+    pino-std-serializers "^7.0.0"
+    process-warning "^4.0.0"
     quick-format-unescaped "^4.0.3"
     real-require "^0.2.0"
     safe-stable-stringify "^2.3.1"
-    sonic-boom "^3.7.0"
-    thread-stream "^2.6.0"
+    sonic-boom "^4.0.1"
+    thread-stream "^3.0.0"
 
 pirates@^4.0.4:
   version "4.0.6"
@@ -6591,15 +6587,10 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-process-warning@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-3.0.0.tgz#96e5b88884187a1dce6f5c3166d611132058710b"
-  integrity sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==
-
-process@^0.11.10:
-  version "0.11.10"
-  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
-  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
+process-warning@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-4.0.0.tgz#581e3a7a1fb456c5f4fd239f76bce75897682d5a"
+  integrity sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw==
 
 promise@^8.3.0:
   version "8.3.0"
@@ -6856,17 +6847,6 @@ readable-stream@^3.4.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readable-stream@^4.0.0:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.5.2.tgz#9e7fc4c45099baeed934bff6eb97ba6cf2729e09"
-  integrity sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==
-  dependencies:
-    abort-controller "^3.0.0"
-    buffer "^6.0.3"
-    events "^3.3.0"
-    process "^0.11.10"
-    string_decoder "^1.3.0"
-
 readable-stream@~2.3.6:
   version "2.3.8"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz"
@@ -7102,9 +7082,9 @@ safe-regex-test@^1.0.0:
     is-regex "^1.1.4"
 
 safe-stable-stringify@^2.3.1:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz#138c84b6f6edb3db5f8ef3ef7115b8f55ccbf886"
-  integrity sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz#4ca2f8e385f2831c432a719b108a3bf7af42a1dd"
+  integrity sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==
 
 "safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
@@ -7303,10 +7283,10 @@ slice-ansi@^2.0.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
-sonic-boom@^3.7.0:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-3.8.1.tgz#d5ba8c4e26d6176c9a1d14d549d9ff579a163422"
-  integrity sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==
+sonic-boom@^4.0.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-4.2.0.tgz#e59a525f831210fa4ef1896428338641ac1c124d"
+  integrity sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==
   dependencies:
     atomic-sleep "^1.0.0"
 
@@ -7340,6 +7320,11 @@ source-map@^0.7.3:
   version "0.7.4"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz"
   integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
+
+spark-md5@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.2.tgz#7952c4a30784347abcee73268e473b9c0167e3fc"
+  integrity sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==
 
 spdx-correct@^3.0.0:
   version "3.2.0"
@@ -7469,7 +7454,7 @@ string.prototype.trimstart@^1.0.7:
     define-properties "^1.2.0"
     es-abstract "^1.22.1"
 
-string_decoder@^1.1.1, string_decoder@^1.3.0:
+string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
@@ -7622,10 +7607,10 @@ theredoc@^1.0.0:
   resolved "https://registry.yarnpkg.com/theredoc/-/theredoc-1.0.0.tgz#bcace376af6feb1873efbdd0f91ed026570ff062"
   integrity sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==
 
-thread-stream@^2.6.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/thread-stream/-/thread-stream-2.7.0.tgz#d8a8e1b3fd538a6cca8ce69dbe5d3d097b601e11"
-  integrity sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==
+thread-stream@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/thread-stream/-/thread-stream-3.1.0.tgz#4b2ef252a7c215064507d4ef70c05a5e2d34c4f1"
+  integrity sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==
   dependencies:
     real-require "^0.2.0"
 
@@ -7870,6 +7855,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-to-istanbul@^9.0.1:
   version "9.1.3"


### PR DESCRIPTION
_Eppo Internal:_
🎟️ **Ticket:** [FF-3769 - Update React Native SDK to use latest common JS module to support non-ascii characters](https://linear.app/eppo/issue/FF-3769/update-react-native-sdk-to-use-latest-common-js-module-to-support-non)
🗨️ **Slack Thread:** ["...flag text encoding problem..."](https://eppo-group.slack.com/archives/C0541NTN6QH/p1735566355776199)
👯 **Related PR:** [`js-sdk-common #187`](https://github.com/Eppo-exp/js-sdk-common/pull/187)

## Motivation and Context
SDKs need to be able to handle special, non-ASCII characters.

## Description
We update our common module, which switches from using [`js-base64`](https://www.npmjs.com/package/js-base64)'s `btoaPolyfill()` and `atobPolyfill()` to `encode` and `decode` respectively.

The former is designed only to handle ASCII characters and bytes ([docs](https://github.com/dankogai/js-base64?tab=readme-ov-file#decode-vs-atob-and-encode-vs-btoa)), while the latter is designed for strings and can handle all characters. 

I've also added the shared test suite to our tests

## How has this been tested?
[Updated shared test case](https://github.com/Eppo-exp/sdk-test-data/pull/103)
