### PR TITLE
fix: non-bandit flags return string assignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/react-native-sdk",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Eppo React Native SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "4.12.0",
+    "@eppo/js-client-sdk-common": "4.13.2",
     "@react-native-async-storage/async-storage": "^1.18.0",
     "spark-md5": "^3.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1213,10 +1213,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@eppo/js-client-sdk-common@4.12.0":
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.12.0.tgz#87836c5cbfbf49beecc832edb12a4da329e4b9ea"
-  integrity sha512-d16xB5prgH1H+OHaFZWXjVgOjyNu90JEH4SWoCxYLjypUQC0mkAw7riLFBDJ0jqQ1L9/EG0SJooXOOQ7tSjBqw==
+"@eppo/js-client-sdk-common@4.13.2":
+  version "4.13.2"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.13.2.tgz#0fffcaa350bfdd12e0ceb2925f543cddd22fd0f8"
+  integrity sha512-XEqajWhqONInZWPxr17iFdUjF3kxqVxe9e2hxa8lHtj4G63pdb/t/3kW6awFL8iz/S8MAurqljnh6X0JRSbGdA==
   dependencies:
     buffer "npm:@eppo/buffer@6.2.0"
     js-base64 "^3.7.7"


### PR DESCRIPTION
---
labels: mergeable
---
_Eppo Internal_
[//]: #  (Link to the issue or doc corresponding to this chunk of work)
🎟️ Fixes: [FF-4105](https://linear.app/eppo/issue/FF-4105/handle-cold-start-bandits-in-precompute-api)

## Motivation and Context
See https://github.com/Eppo-exp/js-sdk-common/pull/238