### PR TITLE
Include Node version in CI setup cache key

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,15 +9,20 @@ runs:
       with:
         node-version: '20.x'  # Specify the Node.js version directly here
 
+    - name: Resolve installed Node version
+      id: node-info
+      run: echo "version=$(node -v)" >> "$GITHUB_OUTPUT"
+      shell: bash
+
     - name: Cache dependencies
       id: yarn-cache
       uses: actions/cache@v3
       with:
         path: |
           **/node_modules
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        key: ${{ runner.os }}-node-${{ steps.node-info.outputs.version }}-yarn-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
-          ${{ runner.os }}-yarn-
+          ${{ runner.os }}-node-${{ steps.node-info.outputs.version }}-yarn-
 
     - name: Install dependencies
       if: steps.yarn-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
[FFESUPPORT-731](https://datadoghq.atlassian.net/browse/FFESUPPORT-731) · stacked on #118

## Summary

The composite setup action caches `**/node_modules` keyed on OS + `yarn.lock` hash only. If a `node_modules` cache built under a different Node version were restored, packages with native bindings could load mismatched ABI binaries — and because the cache-hit path skips the install step, deps wouldn't get rebuilt.

Captures the resolved Node version (`node -v`) into a step output, then includes it in both the primary cache key and the `restore-keys` prefix. Bumping Node now busts the cache automatically instead of relying on lockfile churn.

Pre-existing best-practice gap, not a regression from #118 — flagged by Copilot as a low-confidence observation during the #118 review.

## Notes

Minimal-change variant. Caching Yarn's download cache instead of `node_modules` would be the more robust pattern, but that's a bigger restructure best handled as a separate ticket if we want it.

## Test plan

- [ ] CI green on this branch.
- [ ] Cache hit on a re-run of the same commit (key matches → restore).
- [ ] Verified key changes when Node version changes (by inspection — `node -v` output is captured in the key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)